### PR TITLE
Fixed NullPointerException for Tests Created by Test Data Tag

### DIFF
--- a/src/main/java/org/finra/jtaf/core/model/test/TestComponent.java
+++ b/src/main/java/org/finra/jtaf/core/model/test/TestComponent.java
@@ -33,6 +33,7 @@ public abstract class TestComponent {
 	// TODO: This needs to be stricter
 	private static final Pattern VALID_NAME = Pattern.compile("[^/]+");
 
+	private final String originalName;
 	private String name;
 	private TestNamespace parent;
 
@@ -46,8 +47,21 @@ public abstract class TestComponent {
 		if (!TestComponent.VALID_NAME.matcher(name).matches()) {
 			throw new NameFormatException(name, TestComponent.VALID_NAME);
 		}
-		this.name = name;
+		this.originalName = this.name = name;
 		this.parent = null;
+	}
+
+	/**
+	 * Returns the original name of the {@link TestComponent} when it was created.
+	 * <p>
+	 * This is particularly useful for when plugins alter the name of the test, but the original
+	 * test name is required in order to look up data from the original test.
+	 * </p>
+	 * 
+	 * @return the original name
+	 */
+	public final String getOriginalName() {
+		return originalName;
 	}
 
 	public final String getName() {

--- a/src/main/java/org/finra/jtaf/core/parsing/ScriptParser.java
+++ b/src/main/java/org/finra/jtaf/core/parsing/ScriptParser.java
@@ -226,7 +226,7 @@ public class ScriptParser {
         NodeList list = documentElement.getElementsByTagName("test");
         for (int i = 0; i < list.getLength(); i++) {
             Node n = list.item(i);
-            if (n.getAttributes().getNamedItem("name").getNodeValue().equals(ts.getName())) {
+            if (n.getAttributes().getNamedItem("name").getNodeValue().equals(ts.getOriginalName())) {
                 return n;
             }
         }


### PR DESCRIPTION
This should fix Issue #75.

The fix is to add the original name as field on `TestComponent` on construction. When `ScriptParser` looks up the test's `Node`, it will look up the test by its original name instead of its current name.

Not sure why `ScriptParser` shows a massive change. There's effectively only a single line change at 229. As far as I can tell, they both have CRLF formatting too.